### PR TITLE
Update js4shiny workshop shortlink

### DIFF
--- a/content/blog/2020-02-13-conf2020-workshops/conf2020-workshops.csv
+++ b/content/blog/2020-02-13-conf2020-workshops/conf2020-workshops.csv
@@ -7,7 +7,7 @@ Deep Learning with Keras and TensorFlow in R Workshop,Bradley Boehmke,https://rs
 Designing the Data Science Classroom Workshop,Mine Cetinkaya-Rundel,https://rstd.io/conf20-design-ds-class,
 Introduction to Data Science in the Tidyverse Workshop,"Amelia McNamara, Hadley Wickham",https://rstd.io/conf20-ds-tidy,
 Introduction to Machine Learning with the Tidyverse Workshop,"Alison Hill, Garrett Grolemund",https://rstd.io/conf20-intro-ml,/blog/2020/02/conf20-intro-ml/
-JavaScript for Shiny Users Workshop,Garrick Aden-Buie,https://rstd.io/conf20-shiny-js,
+JavaScript for Shiny Users Workshop,Garrick Aden-Buie,https://rstd.io/conf20-js4shiny,
 Modern Geospatial Data Analysis with R Workshop,Zev Ross,https://rstd.io/conf20-geospatial,
 My Organization's First R Package Workshop,"Rich Iannone, Malcolm Barrett",https://rstd.io/conf20-org-pkg,
 R for Excel Users Workshop,"Julia Lowndes, Allison Horst",https://rstd.io/conf20-r-excel,/blog/2020/02/conf20-r-excel/

--- a/content/blog/2020-02-13-conf2020-workshops/index.markdown
+++ b/content/blog/2020-02-13-conf2020-workshops/index.markdown
@@ -26,7 +26,7 @@ Thanks to all our instructors, teaching assistants, and workshop attendees this 
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', 'Fira Sans', 'Droid Sans', Arial, sans-serif;
 }
 
-#tkwffwodea .gt_table {
+#xxcqmyjwdi .gt_table {
   display: table;
   border-collapse: collapse;
   margin-left: auto;
@@ -43,7 +43,7 @@ Thanks to all our instructors, teaching assistants, and workshop attendees this 
   border-bottom-color: #A8A8A8;
 }
 
-#tkwffwodea .gt_heading {
+#xxcqmyjwdi .gt_heading {
   background-color: #FFFFFF;
   border-bottom-color: #FFFFFF;
   border-left-style: hidden;
@@ -54,7 +54,7 @@ Thanks to all our instructors, teaching assistants, and workshop attendees this 
   border-right-color: #D3D3D3;
 }
 
-#tkwffwodea .gt_title {
+#xxcqmyjwdi .gt_title {
   color: #333333;
   font-size: 125%;
   font-weight: initial;
@@ -64,7 +64,7 @@ Thanks to all our instructors, teaching assistants, and workshop attendees this 
   border-bottom-width: 0;
 }
 
-#tkwffwodea .gt_subtitle {
+#xxcqmyjwdi .gt_subtitle {
   color: #333333;
   font-size: 85%;
   font-weight: initial;
@@ -74,13 +74,13 @@ Thanks to all our instructors, teaching assistants, and workshop attendees this 
   border-top-width: 0;
 }
 
-#tkwffwodea .gt_bottom_border {
+#xxcqmyjwdi .gt_bottom_border {
   border-bottom-style: solid;
   border-bottom-width: 2px;
   border-bottom-color: #D3D3D3;
 }
 
-#tkwffwodea .gt_col_headings {
+#xxcqmyjwdi .gt_col_headings {
   border-top-style: solid;
   border-top-width: 2px;
   border-top-color: #D3D3D3;
@@ -95,7 +95,7 @@ Thanks to all our instructors, teaching assistants, and workshop attendees this 
   border-right-color: #D3D3D3;
 }
 
-#tkwffwodea .gt_col_heading {
+#xxcqmyjwdi .gt_col_heading {
   color: #333333;
   background-color: #FFFFFF;
   font-size: 100%;
@@ -109,7 +109,7 @@ Thanks to all our instructors, teaching assistants, and workshop attendees this 
   overflow-x: hidden;
 }
 
-#tkwffwodea .gt_column_spanner {
+#xxcqmyjwdi .gt_column_spanner {
   color: #333333;
   background-color: #FFFFFF;
   font-size: 100%;
@@ -126,7 +126,7 @@ Thanks to all our instructors, teaching assistants, and workshop attendees this 
   width: 97%;
 }
 
-#tkwffwodea .gt_group_heading {
+#xxcqmyjwdi .gt_group_heading {
   padding: 8px;
   color: #333333;
   background-color: #FFFFFF;
@@ -148,7 +148,7 @@ Thanks to all our instructors, teaching assistants, and workshop attendees this 
   vertical-align: middle;
 }
 
-#tkwffwodea .gt_empty_group_heading {
+#xxcqmyjwdi .gt_empty_group_heading {
   padding: 0.5px;
   color: #333333;
   background-color: #FFFFFF;
@@ -163,19 +163,19 @@ Thanks to all our instructors, teaching assistants, and workshop attendees this 
   vertical-align: middle;
 }
 
-#tkwffwodea .gt_striped {
+#xxcqmyjwdi .gt_striped {
   background-color: rgba(128, 128, 128, 0.05);
 }
 
-#tkwffwodea .gt_from_md > :first-child {
+#xxcqmyjwdi .gt_from_md > :first-child {
   margin-top: 0;
 }
 
-#tkwffwodea .gt_from_md > :last-child {
+#xxcqmyjwdi .gt_from_md > :last-child {
   margin-bottom: 0;
 }
 
-#tkwffwodea .gt_row {
+#xxcqmyjwdi .gt_row {
   padding-top: 8px;
   padding-bottom: 8px;
   padding-left: 5px;
@@ -194,7 +194,7 @@ Thanks to all our instructors, teaching assistants, and workshop attendees this 
   overflow-x: hidden;
 }
 
-#tkwffwodea .gt_stub {
+#xxcqmyjwdi .gt_stub {
   color: #333333;
   background-color: #FFFFFF;
   font-weight: initial;
@@ -205,7 +205,7 @@ Thanks to all our instructors, teaching assistants, and workshop attendees this 
   padding-left: 12px;
 }
 
-#tkwffwodea .gt_summary_row {
+#xxcqmyjwdi .gt_summary_row {
   color: #333333;
   background-color: #FFFFFF;
   text-transform: inherit;
@@ -215,7 +215,7 @@ Thanks to all our instructors, teaching assistants, and workshop attendees this 
   padding-right: 5px;
 }
 
-#tkwffwodea .gt_first_summary_row {
+#xxcqmyjwdi .gt_first_summary_row {
   padding-top: 8px;
   padding-bottom: 8px;
   padding-left: 5px;
@@ -225,7 +225,7 @@ Thanks to all our instructors, teaching assistants, and workshop attendees this 
   border-top-color: #D3D3D3;
 }
 
-#tkwffwodea .gt_grand_summary_row {
+#xxcqmyjwdi .gt_grand_summary_row {
   color: #333333;
   background-color: #FFFFFF;
   text-transform: inherit;
@@ -235,7 +235,7 @@ Thanks to all our instructors, teaching assistants, and workshop attendees this 
   padding-right: 5px;
 }
 
-#tkwffwodea .gt_first_grand_summary_row {
+#xxcqmyjwdi .gt_first_grand_summary_row {
   padding-top: 8px;
   padding-bottom: 8px;
   padding-left: 5px;
@@ -245,7 +245,7 @@ Thanks to all our instructors, teaching assistants, and workshop attendees this 
   border-top-color: #D3D3D3;
 }
 
-#tkwffwodea .gt_table_body {
+#xxcqmyjwdi .gt_table_body {
   border-top-style: solid;
   border-top-width: 2px;
   border-top-color: #D3D3D3;
@@ -254,7 +254,7 @@ Thanks to all our instructors, teaching assistants, and workshop attendees this 
   border-bottom-color: #D3D3D3;
 }
 
-#tkwffwodea .gt_footnotes {
+#xxcqmyjwdi .gt_footnotes {
   color: #333333;
   background-color: #FFFFFF;
   border-bottom-style: none;
@@ -268,13 +268,13 @@ Thanks to all our instructors, teaching assistants, and workshop attendees this 
   border-right-color: #D3D3D3;
 }
 
-#tkwffwodea .gt_footnote {
+#xxcqmyjwdi .gt_footnote {
   margin: 0px;
   font-size: 90%;
   padding: 4px;
 }
 
-#tkwffwodea .gt_sourcenotes {
+#xxcqmyjwdi .gt_sourcenotes {
   color: #333333;
   background-color: #FFFFFF;
   border-bottom-style: none;
@@ -288,46 +288,46 @@ Thanks to all our instructors, teaching assistants, and workshop attendees this 
   border-right-color: #D3D3D3;
 }
 
-#tkwffwodea .gt_sourcenote {
+#xxcqmyjwdi .gt_sourcenote {
   font-size: 90%;
   padding: 4px;
 }
 
-#tkwffwodea .gt_left {
+#xxcqmyjwdi .gt_left {
   text-align: left;
 }
 
-#tkwffwodea .gt_center {
+#xxcqmyjwdi .gt_center {
   text-align: center;
 }
 
-#tkwffwodea .gt_right {
+#xxcqmyjwdi .gt_right {
   text-align: right;
   font-variant-numeric: tabular-nums;
 }
 
-#tkwffwodea .gt_font_normal {
+#xxcqmyjwdi .gt_font_normal {
   font-weight: normal;
 }
 
-#tkwffwodea .gt_font_bold {
+#xxcqmyjwdi .gt_font_bold {
   font-weight: bold;
 }
 
-#tkwffwodea .gt_font_italic {
+#xxcqmyjwdi .gt_font_italic {
   font-style: italic;
 }
 
-#tkwffwodea .gt_super {
+#xxcqmyjwdi .gt_super {
   font-size: 65%;
 }
 
-#tkwffwodea .gt_footnote_marks {
+#xxcqmyjwdi .gt_footnote_marks {
   font-style: italic;
   font-size: 65%;
 }
 </style>
-<div id="tkwffwodea" style="overflow-x:auto;overflow-y:auto;width:auto;height:auto;"><table class="gt_table">
+<div id="xxcqmyjwdi" style="overflow-x:auto;overflow-y:auto;width:auto;height:auto;"><table class="gt_table">
   
   <thead class="gt_col_headings">
     <tr>
@@ -397,7 +397,7 @@ Thanks to all our instructors, teaching assistants, and workshop attendees this 
 </div></td>
     </tr>
     <tr>
-      <td class="gt_row gt_center"><div class='gt_from_md'><p><a href='https://rstd.io/conf20-shiny-js'>JavaScript for Shiny Users Workshop</a></p>
+      <td class="gt_row gt_center"><div class='gt_from_md'><p><a href='https://rstd.io/conf20-js4shiny'>JavaScript for Shiny Users Workshop</a></p>
 </div></td>
       <td class="gt_row gt_center"><div class='gt_from_md'></div></td>
       <td class="gt_row gt_left"><div class='gt_from_md'><p>Garrick Aden-Buie</p>


### PR DESCRIPTION
A quick PR to update the shortlink for my workshop, which was actually `https://rstd.io/conf20-js4shiny`.

I edited via GitHub so apologies that I didn't re-render the blog post etc