### PR TITLE
Bump font sizes for readability

### DIFF
--- a/static/css/edu.css
+++ b/static/css/edu.css
@@ -1,5 +1,6 @@
 body, button, input, textarea {
   font-family: 'Source Sans Pro', sans-serif;
+  font-size: 17px;
   font-weight: normal;
   -webkit-font-smoothing: antialiased; }
 
@@ -126,3 +127,15 @@ details {
   padding-top: 2em;
   border-top: .5em solid #dae8f6;
 }
+
+.listItem .itemDetails .itemDescription {
+  font-size: 16px;
+}
+
+.section .event .eventLocation {
+  font-size: 17px; }
+.section .event .eventDate {
+  font-size: 17px; }
+.section .event .eventDetails {
+  font-size: 16px;
+  }


### PR DESCRIPTION
I went through and tried to make sure we're meeting a minimum of 16px everywhere and bumped the main text to 17px as done in tidymodels.org.

One place where I'm failing to do this is .f6{} which has the text in blue buttons like "TAKE ME THERE" on the main page. This is coming from `tachons.min.css` that is loaded at https://github.com/rstudio/education.rstudio.com/blob/16d33e63ab837ae5ffc786b761a676b76a844b0e/layouts/index.html#L4 and it overwrites `edu.css`. Not sure if we want to hardcode a fix to this or leave it as is.

Closes #82 
