### PR TITLE
render updated .markdown files with links to sample exam solutions

### DIFF
--- a/content/blog/2020-02-05-instructor-certification-exams/index.markdown
+++ b/content/blog/2020-02-05-instructor-certification-exams/index.markdown
@@ -103,8 +103,9 @@ Watch the video embedded below and list feedback you would give the presenter ab
 4.  You may do your work in an R script or an R Markdown file, and may use one for the whole exam or one for each question as your prefer. Whichever you choose, you must send your final work to the examiner by email upon completion of the examination.
 5.  Please let the examiner know when you finish each part of each question so that they can check your work.
 
-### Question 1
+> August 2020: [Marly Gotti](http://www.marlygotti.com/) has created [a solution guide](https://github.com/marlycormar/tidyverse_sample_exam) for this exam.
 
+### Question 1
 
 The file [`at_health_facilities.csv`](./at_health_facilities.csv) contains a tidy dataset with four columns:
 -   The ISO3 code of the country that reported data.

--- a/content/blog/2020-08-18-more-sample-exams/index.markdown
+++ b/content/blog/2020-08-18-more-sample-exams/index.markdown
@@ -22,6 +22,10 @@ but may not ask another person for help, and must complete the exams in 90 minut
 
 ## Tidyverse Exam
 
+*[Brendan Cullen](https://education.rstudio.com/trainers/people/cullen+brendan/)
+has posted [a solution guide](https://tidyverse-exam-v2-solutions.netlify.app/)
+with [source available on GitHub](https://github.com/brendanhcullen/tidyverse-sample-exam-v2.0).*
+
 ### Basic Operations
 
 1.  Read the file [`person.csv`](./person.csv) and store the result in a tibble called `person`.


### PR DESCRIPTION
Hi @gvwilson & @apreshill,

Just a heads up, I think there might have been an issue using `blogdown::serve_site()` with #174 and #180, because I'm only seeing changes in the `index.Rmarkdown` files but not in the rendered `index.markdown` files. For each of these blog posts, I deleted the corresponding `index.markdown` and regenerated them using `blogdown::serve_site()`, which seems to take care of the issue. Sorry to bug you with another PR on an old issue! 

Thanks,
Brendan